### PR TITLE
make alpine version for performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,61 +1,10 @@
-# MIT License
-#
-# Copyright (c) 2021 The NiPreps Developers
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+FROM python:3.8-alpine as builder
 
-# Use Ubuntu 20.04 LTS
-FROM ubuntu:focal-20210416
+RUN apk update && apk add --no-cache curl bzip2 gcc libffi-dev musl-dev
 
-ENV LANG="C.UTF-8" \
-    LC_ALL="C.UTF-8"
+RUN pip install datalad pytest ssh_agent_setup
 
-# Prepare environment
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-                    apt-utils \
-                    ca-certificates \
-                    curl \
-                    netbase \
-                    vim && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM python:3.8-alpine
+COPY --from=builder /usr/local /usr/local
 
-ENV EDITOR=/usr/bin/vim
-
-# Installing and setting up miniconda
-RUN curl -sSLO https://repo.continuum.io/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh && \
-    bash Miniconda3-py38_4.10.3-Linux-x86_64.sh -b -p /opt/miniconda && \
-    rm Miniconda3-py38_4.10.3-Linux-x86_64.sh
-
-# Set CPATH for packages relying on compiled libs (e.g. indexed_gzip)
-ENV PATH="/opt/miniconda/bin:$PATH" \
-    CPATH="/opt/miniconda/include:$CPATH" \
-    PYTHONNOUSERSITE=1
-
-RUN conda install -y -c conda-forge -c anaconda \
-                  datalad \
-                  git-annex \
-                  hub \
-                  jq \
-                  osfclient && \
-    conda clean -y --all && sync && \
-    rm -rf ~/.conda ~/.cache/pip/*; sync
-
-RUN pip install datalad-osf
-
+RUN apk update && apk add --no-cache git openssh-client git-annex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.8-alpine as builder
+FROM python:3.11-alpine as builder
 
 RUN apk update && apk add --no-cache curl bzip2 gcc libffi-dev musl-dev
 
 RUN pip install datalad pytest ssh_agent_setup
 
-FROM python:3.8-alpine
+FROM python:3.11-alpine
 COPY --from=builder /usr/local /usr/local
 
 RUN apk update && apk add --no-cache git openssh-client git-annex

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM python:3.11-alpine as builder
 
 RUN apk update && apk add --no-cache curl bzip2 gcc libffi-dev musl-dev
 
-RUN python -m pip install datalad pytest ssh_agent_setup
+RUN python -m pip install --no-cache-dir datalad pytest ssh_agent_setup
 
 FROM python:3.11-alpine
 COPY --from=builder /usr/local /usr/local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) The NiPreps Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 FROM python:3.11-alpine as builder
 
 RUN apk update && apk add --no-cache curl bzip2 gcc libffi-dev musl-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-alpine as builder
 
 RUN apk update && apk add --no-cache curl bzip2 gcc libffi-dev musl-dev
 
-RUN pip install datalad pytest ssh_agent_setup
+RUN python -m pip install datalad pytest ssh_agent_setup
 
 FROM python:3.11-alpine
 COPY --from=builder /usr/local /usr/local

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 TemplateFlow
+Copyright (c) The NiPreps Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I took your image and tried to make it leaner for faster github actions, and wanted to share it back in case that is of interest.

Python-alpine + multi-stage build results in 241MB image instead of 947MB
It also includes pytest for writing tests using datalad API.
It is also the latest datalad version. 
